### PR TITLE
Change app name to reflect Fairphone name

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Uhr-Widget</string>
+    <string name="app_name">Fairphone Uhr Widget</string>
     <string name="edit">bearbeiten</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Widget Reloj</string>
+    <string name="app_name">Widget reloj de Fairphone</string>
     <string name="edit">editar</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Widget horloge</string>
+    <string name="app_name">Widget horloge Fairphone</string>
     <string name="edit">éditer</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
 
-    <string name="app_name">クロック ウィジェット</string>
+    <string name="app_name">フェアフォン クロック ウィジェット</string>
     <string name="edit">編集</string>
 
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Klok-widget</string>
+    <string name="app_name">Klok-widget van Fairphone</string>
     <string name="edit">bewerk</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Widget Relógio</string>
+    <string name="app_name">Widget relógio de Fairphone</string>
     <string name="edit">editar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
 
-    <string name="app_name">Clock widget</string>
+    <string name="app_name">Fairphone Clock Widget</string>
     <string name="edit">edit</string>
 
 </resources>


### PR DESCRIPTION
This will be better if each lang is updated accordingly, :)

 - [x] French (fr): @Rudloff
 - [x] Japanese (jp): I read some [Japanese press](http://www.gigamen.com/fairphone.html) and [explored romaji](https://j-talk.com/pcrzrrm). I'll be great if some native could check it, though (@naofum?)
 - [x] Deutch (de): @z3ntu
 - [x] Dutch (nl): I asked a person I know speaks Dutch. I'll be great if some native could check it, though (@dosch?)
 - [x] Portuguese (pt): I took some online lessons (Portugal adjoins with Spain, after all. It's great to know your neighbours). 

Could you please comment here the translation of "Fairphone Clock Widget"? I'll take care of including it in the PR