### PR TITLE
Fix widget size

### DIFF
--- a/res/layout/clock_widget_main.xml
+++ b/res/layout/clock_widget_main.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingLeft="28dp">
+    android:paddingStart="28dp">
 
     <TextView
         android:id="@+id/alarm_text"
@@ -10,9 +10,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:drawableLeft="@drawable/clock"
+        android:drawableStart="@drawable/clock"
         android:drawablePadding="8dp"
-        android:gravity="left"
+        android:gravity="start"
         android:textAllCaps="true"
         android:visibility="invisible" />
 
@@ -21,7 +21,7 @@
         android:layout_width="match_parent"
         android:layout_height="92dp"
         android:layout_below="@id/alarm_text"
-        android:layout_marginLeft="-4dp"
+        android:layout_marginStart="-4dp"
         android:orientation="horizontal">
 
         <TextClock
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:format12Hour="@string/big_clock_12_hours_format"
             android:format24Hour="@string/big_clock_24_hours_format"
-            android:gravity="left"
+            android:gravity="start"
             android:includeFontPadding="false" />
 
         <TextView
@@ -38,8 +38,8 @@
             style="@style/text_thin_34sp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="7dp"
-            android:gravity="left"
+            android:layout_marginStart="7dp"
+            android:gravity="start"
             android:includeFontPadding="false"
             android:singleLine="true" />
     </LinearLayout>
@@ -49,14 +49,14 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:layout_below="@id/hour_container"
-        android:layout_marginLeft="4dp">
+        android:layout_marginStart="4dp">
 
         <TextClock
             android:id="@+id/day_of_month"
             style="@style/text_regular_bold_48sp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:format12Hour="@string/day_number_format"
             android:format24Hour="@string/day_number_format"
@@ -66,8 +66,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="8dp"
-            android:layout_toRightOf="@id/day_of_month"
+            android:layout_marginStart="8dp"
+            android:layout_toEndOf="@id/day_of_month"
             android:orientation="vertical">
 
             <LinearLayout
@@ -82,7 +82,7 @@
                     android:layout_height="wrap_content"
                     android:format12Hour="@string/month_format"
                     android:format24Hour="@string/month_format"
-                    android:gravity="left"
+                    android:gravity="start"
                     android:includeFontPadding="false"
                     android:textAllCaps="true" />
 
@@ -90,10 +90,10 @@
                     style="@style/text_light_16sp"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/clock_padding"
+                    android:layout_marginStart="@dimen/clock_padding"
                     android:format12Hour="@string/year_format"
                     android:format24Hour="@string/year_format"
-                    android:gravity="left"
+                    android:gravity="start"
                     android:includeFontPadding="false"
                     android:textAllCaps="true" />
             </LinearLayout>
@@ -102,12 +102,12 @@
                 style="@style/text_regular_bold_22sp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
                 android:layout_below="@id/month_year"
                 android:layout_marginTop="-2dp"
                 android:format12Hour="@string/day_name_format"
                 android:format24Hour="@string/day_name_format"
-                android:gravity="left"
+                android:gravity="start"
                 android:includeFontPadding="false"
                 android:singleLine="true"
                 android:textAllCaps="true" />
@@ -119,15 +119,15 @@
         style="@style/text_condensed_bold_italic_18sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_below="@id/hour_container"
         android:layout_marginTop="20dp"
         android:background="@drawable/button_states_blue"
         android:ellipsize="end"
         android:includeFontPadding="false"
         android:paddingBottom="4dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="8dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
         android:paddingTop="4dp"
         android:singleLine="true"
         android:text="@string/edit" />

--- a/res/layout/clock_widget_main.xml
+++ b/res/layout/clock_widget_main.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingLeft="28dp">
 
     <TextView
         android:id="@+id/alarm_text"
@@ -9,9 +10,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:layout_marginLeft="30.7dp"
         android:drawableLeft="@drawable/clock"
-        android:drawablePadding="8.7dp"
+        android:drawablePadding="8dp"
         android:gravity="left"
         android:textAllCaps="true"
         android:visibility="invisible" />
@@ -19,9 +19,9 @@
     <LinearLayout
         android:id="@+id/hour_container"
         android:layout_width="match_parent"
-        android:layout_height="119.7dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginLeft="25dp"
+        android:layout_height="92dp"
+        android:layout_below="@id/alarm_text"
+        android:layout_marginLeft="-4dp"
         android:orientation="horizontal">
 
         <TextClock
@@ -47,32 +47,33 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="56.3dp"
-        android:layout_marginLeft="31.33dp"
-        android:layout_marginTop="113.8dp">
+        android:layout_height="56dp"
+        android:layout_below="@id/hour_container"
+        android:layout_marginLeft="4dp">
 
         <TextClock
-            style="@style/text_regular_bold_48sp"
             android:id="@+id/day_of_month"
+            style="@style/text_regular_bold_48sp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
             android:layout_centerVertical="true"
             android:format12Hour="@string/day_number_format"
             android:format24Hour="@string/day_number_format"
-            android:includeFontPadding="false"/>
+            android:includeFontPadding="false" />
 
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
+            android:layout_marginLeft="8dp"
             android:layout_toRightOf="@id/day_of_month"
-            android:layout_marginLeft="6.67dp"
             android:orientation="vertical">
 
             <LinearLayout
+                android:id="@+id/month_year"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:id="@+id/month_year"
                 android:orientation="horizontal">
 
                 <TextClock
@@ -89,20 +90,21 @@
                     style="@style/text_light_16sp"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/clock_padding"
                     android:format12Hour="@string/year_format"
                     android:format24Hour="@string/year_format"
                     android:gravity="left"
                     android:includeFontPadding="false"
-                    android:paddingLeft="@dimen/clock_padding"
                     android:textAllCaps="true" />
             </LinearLayout>
 
             <TextClock
                 style="@style/text_regular_bold_22sp"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
                 android:layout_below="@id/month_year"
-                android:layout_marginTop="-2.7dp"
+                android:layout_marginTop="-2dp"
                 android:format12Hour="@string/day_name_format"
                 android:format24Hour="@string/day_name_format"
                 android:gravity="left"
@@ -118,14 +120,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
+        android:layout_below="@id/hour_container"
+        android:layout_marginTop="20dp"
         android:background="@drawable/button_states_blue"
         android:ellipsize="end"
-        android:layout_marginTop="136.9dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp"
-        android:paddingLeft="6dp"
-        android:paddingRight="6dp"
         android:includeFontPadding="false"
+        android:paddingBottom="4dp"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:paddingTop="4dp"
         android:singleLine="true"
         android:text="@string/edit" />
 

--- a/res/layout/widget_main.xml
+++ b/res/layout/widget_main.xml
@@ -5,7 +5,7 @@
 
     <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="180dp"
+        android:layout_height="wrap_content"
         android:layout_centerInParent="true">
 
         <include

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -24,7 +24,7 @@
     <dimen name="text_size_90sp">90dp</dimen>
 
     <!-- Widget dimens -->
-    <dimen name="clock_widget_height">140dp</dimen>
+    <dimen name="clock_widget_height">120dp</dimen>
 
     <!-- Widget sizing best practices
          from https://developer.android.com/guide/practices/ui_guidelines/widget_design#design -->

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -23,6 +23,15 @@
     <dimen name="text_size_22sp">22dp</dimen>
     <dimen name="text_size_90sp">90dp</dimen>
 
+    <!-- Widget dimens -->
+    <dimen name="clock_widget_height">140dp</dimen>
 
+    <!-- Widget sizing best practices
+         from https://developer.android.com/guide/practices/ui_guidelines/widget_design#design -->
+    <dimen name="min_1_cell">40dp</dimen>
+    <dimen name="min_2_cells">110dp</dimen>
+    <dimen name="min_3_cells">280dp</dimen>
+    <dimen name="min_4_cells">250dp</dimen>
+    <!-- n cells 	70 × n − 30 -->
 
 </resources>

--- a/res/xml/clock_widget_info.xml
+++ b/res/xml/clock_widget_info.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/widget_main"
-    android:minWidth="300dp"
-    android:minHeight="180dp"
+    android:minHeight="@dimen/clock_widget_height"
+    android:minWidth="@dimen/min_4_cells"
     android:previewImage="@drawable/widget_clock_icon"
     android:resizeMode="none"
     android:updatePeriodMillis="1800000"
-    android:widgetCategory="home_screen|keyguard">
-</appwidget-provider>
+    android:widgetCategory="home_screen|keyguard" />


### PR DESCRIPTION
Fixes: #2 and #6
Bonus: adds compatibility to right-to-left layouts

This PR improves the chances for the widget to take up 2 rows and 4 columns. It also refactors the UI code and normalize dimensions with a normal unit of `4dp`.